### PR TITLE
Songs Names Scraper_updated

### DIFF
--- a/Songs Names Scraper_updated.ipynb
+++ b/Songs Names Scraper_updated.ipynb
@@ -1,0 +1,196 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from urllib.request import urlopen\n",
+    "from bs4 import BeautifulSoup\n",
+    "from time import sleep\n",
+    "import csv\n",
+    "import requests\n",
+    "import urllib\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Changelog:\n",
+    "\n",
+    "This code is based on the following Github repo:https://github.com/aakashbansal/Songs-Lyrics-Web-Scraper\n",
+    "\n",
+    " The original \"html_page = urlopen(artist_url)\" line gave a 403 - Forbidden error,\n",
+    "This is caused because some websites need to verify the user agent, to prevent from an abnormal visit\n",
+    "\n",
+    " Song names could be scraped from azlyrics more effectively as they have a broader library,\n",
+    "The base_url is changed to azlyrics. The {0} and {1} in the url are placeholder values for the first character in the artists' name and their full name\n",
+    "\n",
+    " Since we're scraping a different site, we're no longer scraping for a table with Soup. Therefore soup_find parameters are change to soup_find_all('div', attrs={'class':'listalbum-item'})\n",
+    "\n",
+    "These changes are made by github user \"matyasmarton\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# url to scrape the songs list from\n",
+    "base_url = \"https://www.azlyrics.com/{0}/{1}.html\"\n",
+    "\n",
+    "\n",
+    "# artists list whose songs list is to be made\n",
+    "artists = [\"vincestaples\",\"dannybrown\"]\n",
+    "#album = \"Xxx\"\n",
+    "songs_dict = { }    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['v', 'd']"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "firsts = [w[0] for w in artists]\n",
+    "firsts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Going to url :  https://www.azlyrics.com/v/vincestaples.html\n",
+      "Artist :  vincestaples\n",
+      "['Progressive 2', 'Beeper King Exclusive', 'Trigga Witta Heart', 'Baron Davis', '102']\n",
+      "Going to url :  https://www.azlyrics.com/d/dannybrown.html\n",
+      "Artist :  dannybrown\n",
+      "['Broadcaster', \"It's A Discription\", 'Yo Lovin', 'Live Every Day', 'Save My People']\n"
+     ]
+    }
+   ],
+   "source": [
+    "for artist in artists:\n",
+    "    artist_url = base_url.format(artist[0],artist)\n",
+    "    print(\"Going to url : \", artist_url)\n",
+    "    \n",
+    "    req = urllib.request.Request(artist_url, headers={'User-Agent' : \"Magic Browser\"})\n",
+    "    con = urllib.request.urlopen( req )\n",
+    "\n",
+    "\n",
+    "    soup = BeautifulSoup(con, 'html.parser')\n",
+    "\n",
+    "    songs_list = soup.find_all('div', attrs={'class':'listalbum-item'})\n",
+    "\n",
+    "    songs_dict[artist] = []\n",
+    "\n",
+    "    for song in songs_list:\n",
+    "        song_name = song.text.strip()\n",
+    "        songs_dict[artist].append(song_name)\n",
+    "\n",
+    "    print(\"Artist : \", artist)\n",
+    "    print(songs_dict[artist][:5])\n",
+    "\n",
+    "    sleep(10)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "vincestaples 118\n",
+      "dannybrown 119\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "for key,val in songs_dict.items():\n",
+    "    print(key,len(val))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "json_file = \"Artists-Songs Mapping.json\"\n",
+    "with open(json_file, 'w') as file:\n",
+    "    json.dump(songs_dict, file)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'vincestaples': ['Progressive 2', 'Beeper King Exclusive', 'Trigga Witta Heart', 'Baron Davis', '102', 'Versace Rap', 'Phat Wemin', 'Hostile', 'SOB', 'Aintnofun', 'Swiss Army', 'Dreams Turn', 'Taxi', 'Winter In Prague', 'Lord', 'Twitch', 'Waterpark', 'Matlock', 'Traffic', 'Black Oprah', 'Queenzbridge Zoo', 'Barreta Scott King', 'Champagne Wishlist', 'Martin Ruger King', 'Vicoden', 'Super', 'More Milli', 'Gold Chain Ricky', 'Cassie Cut (Snippet)', 'Intro', 'Fantoms', 'Heaven', 'Guns & Roses', \"Back Sellin' Crack\", 'Stuck In My Ways', \"Killin' Y'all\", 'Thought About You', 'Sleep', 'Outro', 'Progressive 3', 'Locked & Loaded', 'Humble', '45', 'Oh You Scared', 'Trunk Rattle', 'Nate', 'Turn', 'Shots', 'Earth Science', 'Fire', '65 Hunnid', 'Screen Door', 'Hands Up', 'Blue Suede', 'Limos', \"Feelin' The Love\", 'Lift Me Up', 'Norf Norf', 'Birds & Bees', 'Loca', 'Lemme Know', 'Dopeman', 'Jump Off The Roof', 'Señorita', 'Summertime', 'Ramona Park Legend, Pt. 2', '3230', 'Surf', 'Might Be Wrong', 'Get Paid', 'Street Punks', \"Hang N' Bang\", 'C.N.B.', 'Like It Is', \"'06\", 'Let It Shine', 'War Ready', 'Smile', 'Loco', 'Prima Donna', 'Pimp Hand', 'Big Time', 'Crabs In A Bucket', 'Big Fish', 'Alyssa Interlude', 'Love Can Be...', '745', 'Ramona Park Is Yankee Stadium', 'Yeah Right', 'Homage', 'SAMO', 'Party People', 'BagBak', 'Rain Come Down', 'Feels Like Summer', 'Outside!', \"Don't Get Chipped\", 'Relay', 'New Earlsweatshirt (Interlude)', 'Run The Bands', 'FUN!', 'No Bleedin', 'Brand New Tyga (Interlude)', '(562) 453-9382 (Skit)', \"Tweakin'\", 'So What? (Episode 01)', 'Sheet Music (Episode 02)', 'Funk Flex Freestyle #019', 'Get The Fuck Off My Dick', 'Get Up', 'Hell Bound (Ad 01)', 'Home(from \"Spider-Man: Into The Spider-Verse\" soundtrack)', 'Ice Cold (Final Round)', 'Opps(from \"Black Panther\" soundtrack)', 'Rubbin Off The Paint (Freestyle)', 'Sizzurp', 'XXL Freshman 2015 - Vince Staples Freestyle', 'Yo Love(from \"Queen & Slim\" soundtrack)'], 'dannybrown': ['Broadcaster', \"It's A Discription\", 'Yo Lovin', 'Live Every Day', 'Save My People', 'Track 03 (Shyne Instrumental)', 'Demons And Angel', 'Metal Gear Solid', 'Stay On', 'Change', 'Detroit State Of Mind Pt. 2', 'Bag Back', 'Contra', 'Fruit Cocktail', 'Counterfeit', 'The Wizard', 'Greatest Rapper Ever', 'Need Another Drink', 'New Era', 'Exotic', \"I'm Out\", 'Re-Up', 'Nowhere 2 Go', \"Shootin' Moves\", 'The Nana Song', 'Guitar Solo', 'White Stripes', 'Juno', 'Thank God', 'Drinks On Me', 'Generation Rx', 'S.O.S.', '8 Mile', 'The Hybrid', 'Demons And Angel', 'Metal Gear Solid', 'Tea Time', 'Stay On', 'XXX', 'Die Like A Rockstar', 'Pac Blood', 'Radio Song', 'Lie4', 'I Will', 'Bruiser Brigade', 'Detroit 187', 'Monopoly', 'Blunt After Blunt', 'Outer Space', 'Adderall Admiral', 'DNA', 'Nosebleeds', 'Party All The Time', 'EWNESW', 'Fields', 'Scrap Or Die', '30', 'Baseline(iTunes Deluxe Edition Bonus Track)', 'Witit(iTunes Deluxe Edition Bonus Track)', \"Shouldn't Of(iTunes Deluxe Edition Bonus Track)\", 'Side A (Old)', 'The Return', '25 Bucks', 'Wonderbread', 'Gremlins', 'Dope Fiend Rental', 'Torture', 'Lonely', 'Clean Up', 'Red 2 Go', 'Side B (Dope Song)', 'Dubstep', 'Dip', 'Smokin & Drinkin', 'Break It (Go)', 'Handstand', 'Way Up Here', 'Kush Coma', 'Float On', 'Downward Spiral', \"Tell Me What I Don't Know\", 'Rolling Stone', 'Really Doe', 'Lost', \"Ain't It Funny\", 'Goldust', 'White Lines', 'Pneumonia', 'Dance In The Water', 'From The Ground', 'When It Rain', 'Today', 'Get Hi', 'Hell For It', 'Change Up', 'Theme Song', 'Dirty Laundry', '3 Tearz', 'Belly Of The Beast', 'Savage Nomad', 'Best Life', 'uknowhatimsayin¿', 'Negro Spiritual', 'Shine', 'Combat', 'Brown Eyes', 'Cartier', 'Express Yourself', 'Fresh Off The Boat', 'Grown Up', 'Head For Free', 'Hottest MC', 'Jealousy', 'Kool Aid(from \"Silicon Valley\" soundtrack)', 'Molly Ringwald', 'ODB', 'Radio Head', 'Ready To Go', 'Sweeney Song']}\n"
+     ]
+    }
+   ],
+   "source": [
+    "with open(json_file) as f:\n",
+    "    a = json.load(f)\n",
+    "    print(a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
The original Songs Names Scraper had 3 issues.
- When opening the website with urlopen request the user receives a 403 error, which is caused because the website is looking for a User Agent
- The website changed to azlyrics.com as they have a larger library of artists and lyrics
- The soup parameters have been changed to fit the HTML code of azlyrics.com